### PR TITLE
作ったもの: sacloud-api-tester

### DIFF
--- a/static/data.json
+++ b/static/data.json
@@ -98,7 +98,6 @@
       "text": "ブラウザからさくらのクラウドAPIを実行できるクライアント「sacloud-api-tester」",
       "url": "http://kuroeveryday.blogspot.com/2016/12/sacloud-api-tester.html"
     },
-  "products": [
     {
       "date": "2016/04/17",
       "text": "Slack上からさくらのクラウドを操作できるbot「sacloud-bot」",

--- a/static/data.json
+++ b/static/data.json
@@ -94,6 +94,12 @@
   ],
   "products": [
     {
+      "date": "2016/12/06",
+      "text": "ブラウザからさくらのクラウドAPIを実行できるクライアント「sacloud-api-tester」",
+      "url": "http://kuroeveryday.blogspot.com/2016/12/sacloud-api-tester.html"
+    },
+  "products": [
+    {
       "date": "2016/04/17",
       "text": "Slack上からさくらのクラウドを操作できるbot「sacloud-bot」",
       "url": "http://kuroeveryday.blogspot.com/2016/04/slack-sacloud-bot.html"


### PR DESCRIPTION
ブラウザからさくらのクラウドAPIを実行できるクライアント「sacloud-api-tester」を追加

ブログ: [Vue\.js\+Vuex、Express4、Dockerなどを使ってさくらのクラウドのAPIクライアントを作った](http://kuroeveryday.blogspot.jp/2016/12/sacloud-api-tester.html)